### PR TITLE
just inherit from the memcached 1.5 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,1 @@
-FROM alpine:3.8
-
-RUN apk add --no-cache memcached
-
-EXPOSE 11211
-
-CMD ["memcached", "-u", "nobody"]
+FROM memcached:1.5


### PR DESCRIPTION
I tested this by modifying the image to this:

```
FROM memcached:1.5
USER root
RUN apt-get update \
&& apt-get install -y --no-install-recommends --no-install-suggests procps telnet
USER memcache
```

I then connected to the container's shell and was able to telnet to 11211 on localhost and issue a stats command and get all the memcached stats. I then removed the telnet and ps install etc.. since I only need them to test that memcached was running
